### PR TITLE
Make changes following AO Feedback

### DIFF
--- a/CRM/Aoservicelisting/Form/ProviderApplicationForm.php
+++ b/CRM/Aoservicelisting/Form/ProviderApplicationForm.php
@@ -131,6 +131,8 @@ class CRM_Aoservicelisting_Form_ProviderApplicationForm extends CRM_Aoservicelis
     $this->buildCustom(SERVICELISTING_PROFILE2, 'profile2');
     $this->assign('REGULATED_SERVICE_CF', REGULATED_SERVICE_CF);
     $this->assign('IS_REGULATED_SERVICE', IS_REGULATED_SERVICE);
+    $this->assign('OTHER_LANGUAGE', OTHER_LANGUAGE);
+    $this->assign('LANGUAGES', LANGUAGES);
     $this->assign('regulator_services', json_encode(CRM_Core_OptionGroup::values('regulator_url_mapping')));
 
     // this part is to render camp fields

--- a/aoservicelisting.constants.inc
+++ b/aoservicelisting.constants.inc
@@ -13,3 +13,5 @@
   define('STATUS', 'custom_904');
   define('RECEIVED_MESSAGE', 90);
   define('APPROVED_MESSAGE', 91);
+  define('OTHER_LANGUAGE', 'custom_905');
+  define('LANGUAGES', 'custom_899');

--- a/templates/CRM/Aoservicelisting/Form/ProviderApplicationForm.tpl
+++ b/templates/CRM/Aoservicelisting/Form/ProviderApplicationForm.tpl
@@ -361,7 +361,7 @@
         }
       });
       var otherLanguageField = $('#editrow-' + {/literal}'{$OTHER_LANGUAGE}'{literal});
-      var languageField = $({/literal}'{$LANGUAGES}'{literal});
+      var languageField = $('#' + {/literal}'{$LANGUAGES}'{literal});
       var languageValues = languageField.val();
       if ($.inArray('Other Language', languageValues) !== -1) {
         otherLanguageField.show();
@@ -370,7 +370,7 @@
         otherLanguageField.hide();
       }
       languageField.change(function() {
-        if (.inArray('Other Language', $(this).val()) !== -1) {
+        if ($.inArray('Other Language', $(this).val()) !== -1) {
           otherLanguageField.show();
         }
         else {

--- a/templates/CRM/Aoservicelisting/Form/ProviderApplicationForm.tpl
+++ b/templates/CRM/Aoservicelisting/Form/ProviderApplicationForm.tpl
@@ -153,14 +153,16 @@
       if (serviceProvider == "1") {
         $('.edit-row-organization_name').hide();
         $('.edit-row-organization_email').hide();
-          $('*[data-crm-custom="service_provider_details:Display_First_Name_and_Last_Name_in_public_listing"][value="1"]').prop({'checked': true});
-          $('*[data-crm-custom="service_provider_details:Display_First_Name_and_Last_Name_in_public_listing"]').parent('div.content').css('pointer-events', 'none');
+        $('*[data-crm-custom="service_provider_details:Display_First_Name_and_Last_Name_in_public_listing"][value="1"]').prop({'checked': true});
+        $('*[data-crm-custom="service_provider_details:Display_First_Name_and_Last_Name_in_public_listing"]').parent('div.content').css('pointer-events', 'none');
+        $('#add-another-staff').hide();
       }
       else {
         $('.edit-row-organization_name').show();
         $('.edit-row-organization_email').show();
         $('*[data-crm-custom="service_provider_details:Display_First_Name_and_Last_Name_in_public_listing"][value="1"]').prop({'checked': true});
         $('*[data-crm-custom="service_provider_details:Display_First_Name_and_Last_Name_in_public_listing"]').parent('div.content').css('pointer-events', 'all');
+        $('#add-another-staff').show();
       }
       $('[name=listing_type]').on('change', function() {
         if ($(this).val() == "1") {
@@ -168,12 +170,14 @@
           $('.edit-row-organization_email').hide();
           $('*[data-crm-custom="service_provider_details:Display_First_Name_and_Last_Name_in_public_listing"][value="1"]').prop({'checked': true});
           $('*[data-crm-custom="service_provider_details:Display_First_Name_and_Last_Name_in_public_listing"]').parent('div.content').css('pointer-events', 'none');
+          $('#add-another-staff').hide();
         }
         else {
           $('.edit-row-organization_name').show();
           $('.edit-row-organization_email').show();
           $('*[data-crm-custom="service_provider_details:Display_First_Name_and_Last_Name_in_public_listing"][value="1"]').prop({'checked': true});
           $('*[data-crm-custom="service_provider_details:Display_First_Name_and_Last_Name_in_public_listing"]').parent('div.content').css('pointer-events', 'all');
+          $('#add-another-staff').show();
         }
       });
 
@@ -278,20 +282,20 @@
           for (var i=1; i<=countcheck; i++) {
             $('#staff_member-' + i).removeClass('hiddenElement');
           }
-          var count = 1;
-          service.each(function(i, v) {
-            var id = v.getAttribute('id');
-            var label = $('label[for="' + id + '"]').html();
-            var field = parseInt(id.split('_').pop());
-            var regulatorMapping = {/literal}'{$regulator_services}'{literal};
-            regulatorMapping = JSON.parse(regulatorMapping);
-            if (field && regulatorMapping.hasOwnProperty(field)) {
-              $('#staff_record_regulator_' + count).val('https://www.' + regulatorMapping[field].split(',').pop());
-              $('.crm-label-' + count).remove();
-              $('#staff_member-' + count).find('div.crm-section:nth-child(3)').append('<div class="content crm-label-' + count + '">' + label + '</div>');
-              count++;
-            }
-          });
+          //var count = 1;
+          //service.each(function(i, v) {
+            //var id = v.getAttribute('id');
+            //var label = $('label[for="' + id + '"]').html();
+            //var field = parseInt(id.split('_').pop());
+            //var regulatorMapping = {/literal}'{$regulator_services}'{literal};
+            //regulatorMapping = JSON.parse(regulatorMapping);
+            //if (field && regulatorMapping.hasOwnProperty(field)) {
+              //$('#staff_record_regulator_' + count).val('https://www.' + regulatorMapping[field].split(',').pop());
+              //$('.crm-label-' + count).remove();
+              //$('#staff_member-' + count).find('div.crm-section:nth-child(3)').append('<div class="content crm-label-' + count + '">' + label + '</div>');
+              //count++;
+            //}
+          //});
         }
       }
 
@@ -321,6 +325,13 @@
         $('#staff_last_name_1').val($(this).val()).trigger('change');
       });
       var selector = {/literal}'{$IS_REGULATED_SERVICE}'{literal};
+      selectorVal = $('[name=' + selector + ']:checked').val();
+      if (selectorVal == "1") {
+        servies.show();
+      }
+      else {
+        services.hide();
+      }
       $('[name=' + selector + ']').change(function() {
         var rsSelector = {/literal}'{$REGULATED_SERVICE_CF}'{literal};
         if ($(this).val() == "1") {

--- a/templates/CRM/Aoservicelisting/Form/ProviderApplicationForm.tpl
+++ b/templates/CRM/Aoservicelisting/Form/ProviderApplicationForm.tpl
@@ -360,6 +360,23 @@
           $('#regulated-staff-message').hide();
         }
       });
+      var otherLanguageField = $('#editrow-' + {/literal}'{$OTHER_LANGUAGE}'{literal});
+      var languageField = $({/literal}'{$LANGUAGES}'{literal});
+      var languageValues = languageField.val();
+      if ($.inArray('Other Language', languageValues) !== -1) {
+        otherLanguageField.show();
+      }
+      else {
+        otherLanguageField.hide();
+      }
+      languageField.change(function() {
+        if (.inArray('Other Language', $(this).val()) !== -1) {
+          otherLanguageField.show();
+        }
+        else {
+          otherLanguageField.hide();
+        }
+      });
     });
   </script>
 {/literal}

--- a/templates/CRM/Aoservicelisting/Form/ProviderApplicationForm.tpl
+++ b/templates/CRM/Aoservicelisting/Form/ProviderApplicationForm.tpl
@@ -325,12 +325,13 @@
         $('#staff_last_name_1').val($(this).val()).trigger('change');
       });
       var selector = {/literal}'{$IS_REGULATED_SERVICE}'{literal};
-      selectorVal = $('[name=' + selector + ']:checked').val();
+      var selectorVal = $('[name=' + selector + ']:checked').val();
+      var regulatedServices =  $('#editrow-' + {/literal}'{$REGULATED_SERVICE_CF}'{literal});
       if (selectorVal == "1") {
-        servies.show();
+        regulatedServices.show();
       }
       else {
-        services.hide();
+        regulatedServices.hide();
       }
       $('[name=' + selector + ']').change(function() {
         var rsSelector = {/literal}'{$REGULATED_SERVICE_CF}'{literal};


### PR DESCRIPTION
This makes the following changes following AO Feedback

1. Disables the pre-filling of the record on regulators site this is potentially confusing, it might be better to have it as a postfield help or something instead
2. Hides the link to add more staff if its an Individual listing
3. Hides the list of regulated services until they select they do provide regulated services
4. Hides a new other languages text field i have added on initial load and only shows it if the user selects Other Language