### PR TITLE
Fix Pre-filling the AOSL Form when primary contact is not an ABA Staf…

### DIFF
--- a/CRM/Aoservicelisting/Form/ProviderApplicationForm.php
+++ b/CRM/Aoservicelisting/Form/ProviderApplicationForm.php
@@ -38,13 +38,14 @@ class CRM_Aoservicelisting_Form_ProviderApplicationForm extends CRM_Aoservicelis
           'return' => ['id', 'first_name', 'last_name', CERTIFICATE_NUMBER]
         ]);
         $primaryContactPhone = civicrm_api3('Phone', 'getsingle', ['contact_id' => $this->_loggedInContactID, 'is_primary' => 1]);
-        $website = civicrm_api3('Website', 'get', ['contact_id' => $staffMemberContactId, 'url' => ['IS NOT NULL' => 1], 'sequential' => 1])['values'];
-        $regulatorUrlPresent = (!empty($website['values']));
+        $website = civicrm_api3('Website', 'get', ['contact_id' => $this->_loggedInContactID, 'url' => ['IS NOT NULL' => 1], 'sequential' => 1])['values'];
+        $regulatorUrlPresent = (!empty($website));
         $staffRowCount = $abaStaffCount = 1;
         if ($regulatorUrlPresent) {
           $defaults['staff_first_name['. $staffRowCount . ']'] = $defaults['primary_first_name'] = $primaryContact['first_name'];
           $defaults['staff_last_name['. $staffRowCount . ']'] = $defaults['primary_last_name'] = $primaryContact['last_name'];
           $defaults['staff_contact_id['. $staffRowCount . ']'] = $this->_loggedInContactID;
+          $defaults['staff_record_regulator[' . $staffRowCount . ']'] = $website[0]['url'];
           $staffRowCount++;
         }
         if (!empty($primaryContact[CERTIFICATE_NUMBER])) {


### PR DESCRIPTION
…f member or regulated staff member and also fix setting the defaults of the website field for regulated staff members

The scenario here is that you have a primary contact that is not a current regulated staff member or ABA staff member. Previously the primary contact details were being added to the regulated staff member when a logged in user viewed the page. Further for the regulated staff the value of `$regulatorUrlPresent ` was being set wrong as well because it was checking for a key that doesn't exist now. 